### PR TITLE
Update Mavic 3 class to C1

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -46,7 +46,7 @@ DJI,Mavic 2 Enterprise Advanced,none,909,909,31,,
 DJI,Mavic 2 Enterprise Dual,none,899,899,31,,
 DJI,Mavic 2 Pro,none,907,907,31,,
 DJI,Mavic 2 Zoom,none,905,905,31,,
-DJI,Mavic 3,none,895,895,46,true,
+DJI,Mavic 3,C1,895,895,46,true,
 DJI,Mavic Air,none,430,430,21,,
 DJI,Mavic Air 2,none,570,570,34,,
 DJI,Mavic Mini,none,249,249,30,true,false


### PR DESCRIPTION
Updated Mavic 3 classification - C1.