### PR TITLE
feat: add Freefly Alta X

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -81,6 +81,7 @@ DJI,Tello,none,80,80,13,true,false
 DJI,Tello EDU,none,80,80,13,true,false
 DJI,Tello Iron Man,none,80,80,13,true,false
 Freefly,Alta X,none,9700,34860,50,,
+Freefly,Astro,none,3095,6665,38,,
 GoPro,Karma,none,1006,1006,20,,
 Hubsan,Zino,none,700,700,45,,
 Hubsan,Zino Pro,none,700,700,43,,

--- a/list.csv
+++ b/list.csv
@@ -80,6 +80,7 @@ DJI,Spreading Wings S900,none,3300,8200,18,,
 DJI,Tello,none,80,80,13,true,false
 DJI,Tello EDU,none,80,80,13,true,false
 DJI,Tello Iron Man,none,80,80,13,true,false
+Freefly,Alta X,none,9700,34860,50,,
 GoPro,Karma,none,1006,1006,20,,
 Hubsan,Zino,none,700,700,45,,
 Hubsan,Zino Pro,none,700,700,43,,


### PR DESCRIPTION
Added Freefly Alta X and Freefly Astro

Data is taken from specifications here:

https://shop.quadrocopter.com/FreeFly-ALTA-X_p_1971.html
https://freeflysystems.com/astro/specs